### PR TITLE
Implement sleep schedule alarm and calendar star logic

### DIFF
--- a/app/__tests__/CalendarPage.test.tsx
+++ b/app/__tests__/CalendarPage.test.tsx
@@ -1,0 +1,27 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from '@testing-library/react';
+import CalendarPage from '../src/pages/CalendarPage';
+import { useSleepStore } from '../src/store/useSleepStore';
+
+beforeEach(() => {
+  useSleepStore.setState({
+    bedTime: '22:00',
+    wakeTime: '06:00',
+    records: [
+      {
+        date: new Date().toISOString().split('T')[0],
+        scheduledBed: '22:00',
+        scheduledWake: '06:00',
+        actualBed: '22:00',
+        actualWake: '06:00',
+        duration: 8,
+        onSchedule: true
+      }
+    ]
+  });
+});
+
+test('displays star for on-schedule sleep', () => {
+  render(<CalendarPage />);
+  expect(screen.getByText('⭐')).toBeInTheDocument();
+});

--- a/app/src/pages/CalendarPage.tsx
+++ b/app/src/pages/CalendarPage.tsx
@@ -16,7 +16,7 @@ export default function CalendarPage() {
           {days.map((d) => {
             const dateStr = d.toISOString().split('T')[0];
             const rec = records.find((r) => r.date === dateStr);
-            const star = rec && rec.duration && rec.duration >= 0 ? '⭐' : '';
+            const star = rec && rec.onSchedule ? '⭐' : '';
             return (
               <td key={dateStr} style={{ padding: '4px', border: '1px solid gray' }}>
                 {d.getDate()}


### PR DESCRIPTION
## Summary
- trigger an alarm at wake time in `TimeSettingPage`
- mark calendar days with a star when sleep matches the schedule
- track on-schedule info and compute duration in `useSleepStore`
- add tests for calendar star behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687dce90426883248426d6abfdb72a4c