### PR TITLE
Translate app UI to Japanese

### DIFF
--- a/app/__tests__/TimeSettingPage.test.tsx
+++ b/app/__tests__/TimeSettingPage.test.tsx
@@ -8,9 +8,9 @@ beforeEach(() => {
 
 test('updates schedule', () => {
   render(<TimeSettingPage />);
-  fireEvent.change(screen.getByLabelText(/Bed Time/i), { target: { value: '23:00' } });
-  fireEvent.change(screen.getByLabelText(/Wake Time/i), { target: { value: '07:00' } });
-  fireEvent.submit(screen.getByRole('button', { name: /save/i }).closest('form')!);
+  fireEvent.change(screen.getByLabelText(/就寝時間/i), { target: { value: '23:00' } });
+  fireEvent.change(screen.getByLabelText(/起床時間/i), { target: { value: '07:00' } });
+  fireEvent.submit(screen.getByRole('button', { name: /保存/i }).closest('form')!);
   const state = useSleepStore.getState();
   expect(state.bedTime).toBe('23:00');
   expect(state.wakeTime).toBe('07:00');
@@ -18,8 +18,8 @@ test('updates schedule', () => {
 
 test('start and stop sleep', () => {
   render(<TimeSettingPage />);
-  fireEvent.click(screen.getByRole('button', { name: /start sleep/i }));
-  fireEvent.click(screen.getByRole('button', { name: /stop sleep/i }));
+  fireEvent.click(screen.getByRole('button', { name: /睡眠開始/i }));
+  fireEvent.click(screen.getByRole('button', { name: /睡眠停止/i }));
   const { records } = useSleepStore.getState();
   expect(records[0].duration).toBeGreaterThanOrEqual(0);
 });

--- a/app/index.html
+++ b/app/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>睡眠アプリ</title>
   </head>
   <body>
     <div id="root"></div>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -5,15 +5,16 @@ import CalendarPage from './pages/CalendarPage';
 import ProfilePage from './pages/ProfilePage';
 
 function ErrorFallback() {
-  return <p role="alert">Something went wrong.</p>;
+  return <p role="alert">エラーが発生しました。</p>;
 }
 
 export default function App() {
   return (
     <BrowserRouter>
       <nav>
-        <Link to="/">Schedule</Link> | <Link to="/calendar">Calendar</Link> |{' '}
-        <Link to="/profile">Profile</Link>
+        <Link to="/">スケジュール</Link> |{' '}
+        <Link to="/calendar">カレンダー</Link> |{' '}
+        <Link to="/profile">プロフィール</Link>
       </nav>
       <ErrorBoundary FallbackComponent={ErrorFallback}>
         <Routes>

--- a/app/src/pages/ProfilePage.tsx
+++ b/app/src/pages/ProfilePage.tsx
@@ -24,20 +24,20 @@ export default function ProfilePage() {
 
   return (
     <div>
-      <h2>Profile</h2>
+      <h2>プロフィール</h2>
       {error && <p role="alert">{error}</p>}
       <input
-        aria-label="Name"
+        aria-label="名前"
         value={name}
         onChange={(e) => setName(e.target.value)}
       />
       <input
-        aria-label="Icon URL"
+        aria-label="アイコンURL"
         value={icon}
         onChange={(e) => setIcon(e.target.value)}
       />
       <button disabled={saving} onClick={handleSave}>
-        Save
+        保存
       </button>
     </div>
   );

--- a/app/src/pages/TimeSettingPage.tsx
+++ b/app/src/pages/TimeSettingPage.tsx
@@ -46,22 +46,22 @@ export default function TimeSettingPage() {
 
   return (
     <div>
-      <h2>Schedule</h2>
+      <h2>スケジュール</h2>
       <form onSubmit={handleSchedule}>
         <label>
-          Bed Time
+          就寝時間
           <input type="time" name="bed" defaultValue={bedTime} />
         </label>
         <label>
-          Wake Time
+          起床時間
           <input type="time" name="wake" defaultValue={wakeTime} />
         </label>
-        <button type="submit">Save</button>
+        <button type="submit">保存</button>
       </form>
       {sleeping ? (
-        <button onClick={handleStop}>Stop Sleep</button>
+        <button onClick={handleStop}>睡眠停止</button>
       ) : (
-        <button onClick={handleStart}>Start Sleep</button>
+        <button onClick={handleStart}>睡眠開始</button>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- translate navigation and pages to Japanese
- switch HTML language and title
- update tests for Japanese labels

## Testing
- `npm test --silent` *(fails: Cannot find module 'bs-logger/dist/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_687dd9e406348324b85c17553db56050