### PR TITLE
Add monthly calendar and weekly graph

### DIFF
--- a/app/__tests__/WeeklyGraphPage.test.tsx
+++ b/app/__tests__/WeeklyGraphPage.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import WeeklyGraphPage from '../src/pages/WeeklyGraphPage';
+import { useSleepStore } from '../src/store/useSleepStore';
+
+describe('WeeklyGraphPage', () => {
+  beforeEach(() => {
+    const today = new Date();
+    const dayOfWeek = today.getDay();
+    const sunday = new Date(today);
+    sunday.setDate(today.getDate() - dayOfWeek);
+    const records = Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(sunday);
+      d.setDate(sunday.getDate() + i);
+      return {
+        date: d.toISOString().split('T')[0],
+        scheduledBed: '22:00',
+        scheduledWake: '06:00',
+        actualBed: '22:00',
+        actualWake: '06:00',
+        duration: 8
+      };
+    });
+    useSleepStore.setState({ bedTime: '22:00', wakeTime: '06:00', records });
+  });
+
+  test('renders 7 bars', () => {
+    render(<WeeklyGraphPage />);
+    expect(screen.getAllByRole('progressbar')).toHaveLength(7);
+  });
+});

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import { ErrorBoundary } from 'react-error-boundary';
 import TimeSettingPage from './pages/TimeSettingPage';
 import CalendarPage from './pages/CalendarPage';
+import WeeklyGraphPage from './pages/WeeklyGraphPage';
 import ProfilePage from './pages/ProfilePage';
 
 function ErrorFallback() {
@@ -14,12 +15,14 @@ export default function App() {
       <nav>
         <Link to="/">スケジュール</Link> |{' '}
         <Link to="/calendar">カレンダー</Link> |{' '}
+        <Link to="/weekly">グラフ</Link> |{' '}
         <Link to="/profile">プロフィール</Link>
       </nav>
       <ErrorBoundary FallbackComponent={ErrorFallback}>
         <Routes>
           <Route path="/" element={<TimeSettingPage />} />
           <Route path="/calendar" element={<CalendarPage />} />
+          <Route path="/weekly" element={<WeeklyGraphPage />} />
           <Route path="/profile" element={<ProfilePage />} />
         </Routes>
       </ErrorBoundary>

--- a/app/src/pages/CalendarPage.tsx
+++ b/app/src/pages/CalendarPage.tsx
@@ -2,29 +2,40 @@ import { useSleepStore } from '../store/useSleepStore';
 
 export default function CalendarPage() {
   const { records } = useSleepStore();
-  const today = new Date();
-  const start = new Date(today.getFullYear(), today.getMonth(), 1);
-  const days = new Array(31).fill(0).map((_, i) => {
-    const d = new Date(start.getFullYear(), start.getMonth(), i + 1);
-    return d;
-  });
+  const year = new Date().getFullYear();
+  const months = Array.from({ length: 12 }, (_, i) => i);
+  const days = Array.from({ length: 31 }, (_, i) => i + 1);
 
   return (
     <table>
-      <tbody>
+      <thead>
         <tr>
-          {days.map((d) => {
-            const dateStr = d.toISOString().split('T')[0];
-            const rec = records.find((r) => r.date === dateStr);
-            const star = rec && rec.onSchedule ? '⭐' : '';
-            return (
-              <td key={dateStr} style={{ padding: '4px', border: '1px solid gray' }}>
-                {d.getDate()}
-                <div>{star}</div>
-              </td>
-            );
-          })}
+          <th></th>
+          {days.map((d) => (
+            <th key={d}>{d}</th>
+          ))}
         </tr>
+      </thead>
+      <tbody>
+        {months.map((m) => (
+          <tr key={m}>
+            <th>{m + 1}月</th>
+            {days.map((d) => {
+              const date = new Date(year, m, d);
+              const dateStr = date.toISOString().split('T')[0];
+              const rec = records.find((r) => r.date === dateStr);
+              const star = rec && rec.onSchedule ? '⭐' : '';
+              return (
+                <td
+                  key={`${m}-${d}`}
+                  style={{ padding: '4px', border: '1px solid gray' }}
+                >
+                  {star}
+                </td>
+              );
+            })}
+          </tr>
+        ))}
       </tbody>
     </table>
   );

--- a/app/src/pages/WeeklyGraphPage.tsx
+++ b/app/src/pages/WeeklyGraphPage.tsx
@@ -1,0 +1,42 @@
+import { useSleepStore } from '../store/useSleepStore';
+
+export default function WeeklyGraphPage() {
+  const { records } = useSleepStore();
+
+  const now = new Date();
+  const dayOfWeek = now.getDay();
+  const sunday = new Date(now);
+  sunday.setDate(now.getDate() - dayOfWeek);
+  sunday.setHours(0, 0, 0, 0);
+
+  const days = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(sunday);
+    d.setDate(sunday.getDate() + i);
+    return d;
+  });
+
+  return (
+    <div>
+      <h2>直近一週間の睡眠時間</h2>
+      {days.map((d) => {
+        const dateStr = d.toISOString().split('T')[0];
+        const rec = records.find((r) => r.date === dateStr);
+        const val = rec?.duration ?? 0;
+        return (
+          <div key={dateStr} style={{ margin: '4px 0' }}>
+            <div>{dateStr}</div>
+            <div
+              role="progressbar"
+              style={{
+                width: `${val * 30}px`,
+                height: '20px',
+                background: 'skyblue'
+              }}
+            />
+            <span>{val.toFixed(1)}h</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/src/store/useSleepStore.ts
+++ b/app/src/store/useSleepStore.ts
@@ -63,8 +63,10 @@ export const useSleepStore = create<SleepState>((set) => ({
           const duration =
             r.actualBed && time
               ?
-                  (new Date(`${today}T${time}`).getTime() -
-                    new Date(`${today}T${r.actualBed}`).getTime()) /
+                  Math.abs(
+                    new Date(`${today}T${time}`).getTime() -
+                      new Date(`${today}T${r.actualBed}`).getTime()
+                  ) /
                   3600000
               : r.duration;
           const onSchedule =


### PR DESCRIPTION
## Summary
- show months January to December on the calendar page
- compute sleep duration as absolute difference between sleep and wake times
- add weekly graph page displaying last week's sleep duration
- link to the new graph page in the nav
- test weekly graph rendering

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687ddecb878083249b20ae08feedba23