### PR TITLE
Add current date display on schedule page

### DIFF
--- a/app/__tests__/TimeSettingPage.test.tsx
+++ b/app/__tests__/TimeSettingPage.test.tsx
@@ -7,6 +7,12 @@ beforeEach(() => {
   useSleepStore.setState({ bedTime: '22:00', wakeTime: '06:00', records: [] });
 });
 
+test('displays today date', () => {
+  render(<TimeSettingPage />);
+  const today = new Date().toISOString().split('T')[0];
+  expect(screen.getByLabelText(/日付/i)).toHaveValue(today);
+});
+
 test('updates schedule', () => {
   render(<TimeSettingPage />);
   fireEvent.change(screen.getByLabelText(/就寝時間/i), { target: { value: '23:00' } });

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -5,5 +5,6 @@ export default {
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/src/$1'
   },
+  modulePathIgnorePatterns: ['<rootDir>/functions/', '<rootDir>/sleep-tracker/'],
   testTimeout: 30000
 };

--- a/app/src/pages/TimeSettingPage.tsx
+++ b/app/src/pages/TimeSettingPage.tsx
@@ -5,6 +5,7 @@ import { useSleepStore } from '../store/useSleepStore';
 export default function TimeSettingPage() {
   const { bedTime, wakeTime, setSchedule, startSleep, stopSleep } =
     useSleepStore();
+  const today = new Date().toISOString().split('T')[0];
   const [sleeping, setSleeping] = useState(false);
   const [elapsed, setElapsed] = useState(0);
   const alarmRef = useRef<number | null>(null);
@@ -75,6 +76,10 @@ export default function TimeSettingPage() {
         <label>
           起床時間
           <input type="time" name="wake" defaultValue={wakeTime} />
+        </label>
+        <label>
+          日付
+          <input type="date" name="date" value={today} readOnly />
         </label>
         <button type="submit">保存</button>
       </form>


### PR DESCRIPTION
## Summary
- show today's date in schedule page
- cover schedule date display with a new RTL test
- ignore extra packages when running Jest

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687de29b47b083249e481088e0c6a5ed