### PR TITLE
Add sleep log list and chart

### DIFF
--- a/app/__tests__/SleepLogList.test.tsx
+++ b/app/__tests__/SleepLogList.test.tsx
@@ -1,0 +1,41 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen, fireEvent } from '@testing-library/react';
+import SleepLogList from '../src/components/SleepLogList';
+import { SleepLog } from '../src/types/SleepLog';
+
+describe('SleepLogList', () => {
+  const logs: SleepLog[] = [
+    {
+      id: 1,
+      sleepTime: new Date('2024-01-01T22:00:00').getTime(),
+      wakeTime: new Date('2024-01-02T06:00:00').getTime(),
+      memo: 'good'
+    },
+    {
+      id: 2,
+      sleepTime: new Date('2024-01-02T23:00:00').getTime(),
+      wakeTime: new Date('2024-01-03T07:00:00').getTime()
+    }
+  ];
+
+  beforeEach(() => {
+    localStorage.setItem('sleepLogs', JSON.stringify(logs));
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('renders logs and bars', async () => {
+    render(<SleepLogList />);
+    expect(await screen.findAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getAllByRole('progressbar')).toHaveLength(2);
+  });
+
+  test('deletes a log', async () => {
+    render(<SleepLogList />);
+    const delButtons = await screen.findAllByRole('button', { name: '削除' });
+    fireEvent.click(delButtons[0]);
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+  });
+});

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,6 +3,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import TimeSettingPage from './pages/TimeSettingPage';
 import CalendarPage from './pages/CalendarPage';
 import WeeklyGraphPage from './pages/WeeklyGraphPage';
+import SleepLogsPage from './pages/SleepLogsPage';
 import ProfilePage from './pages/ProfilePage';
 
 function ErrorFallback() {
@@ -16,6 +17,7 @@ export default function App() {
         <Link to="/">スケジュール</Link> |{' '}
         <Link to="/calendar">カレンダー</Link> |{' '}
         <Link to="/weekly">グラフ</Link> |{' '}
+        <Link to="/logs">ログ</Link> |{' '}
         <Link to="/profile">プロフィール</Link>
       </nav>
       <ErrorBoundary FallbackComponent={ErrorFallback}>
@@ -23,6 +25,7 @@ export default function App() {
           <Route path="/" element={<TimeSettingPage />} />
           <Route path="/calendar" element={<CalendarPage />} />
           <Route path="/weekly" element={<WeeklyGraphPage />} />
+          <Route path="/logs" element={<SleepLogsPage />} />
           <Route path="/profile" element={<ProfilePage />} />
         </Routes>
       </ErrorBoundary>

--- a/app/src/components/SleepChart.tsx
+++ b/app/src/components/SleepChart.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { SleepLog } from '../types/SleepLog';
+
+interface Props {
+  logs: SleepLog[];
+}
+
+const BAR_WIDTH = 20;
+const SCALE = 20; // px per hour
+
+const SleepChart: React.FC<Props> = ({ logs }) => {
+  const durations = logs.map((l) =>
+    Math.max(0, (l.wakeTime - l.sleepTime) / 3600000)
+  );
+  const max = Math.max(...durations, 0);
+  const height = max * SCALE;
+
+  return (
+    <div
+      role="group"
+      aria-label="睡眠時間グラフ"
+      style={{ display: 'flex', alignItems: 'flex-end', gap: '4px', height }}
+    >
+      {durations.map((d, i) => (
+        <div
+          key={logs[i].id}
+          role="progressbar"
+          aria-label={`${d.toFixed(1)}h`}
+          style={{
+            width: BAR_WIDTH,
+            height: d * SCALE,
+            background: 'skyblue'
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default SleepChart;

--- a/app/src/components/SleepLogList.tsx
+++ b/app/src/components/SleepLogList.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { SleepLog } from '../types/SleepLog';
+import SleepChart from './SleepChart';
+
+const STORAGE_KEY = 'sleepLogs';
+
+const SleepLogList: React.FC = () => {
+  const [logs, setLogs] = useState<SleepLog[]>([]);
+
+  useEffect(() => {
+    const existing = localStorage.getItem(STORAGE_KEY);
+    const parsed: SleepLog[] = existing ? JSON.parse(existing) : [];
+    setLogs(parsed);
+  }, []);
+
+  const handleDelete = (id: number) => {
+    const newLogs = logs.filter((log) => log.id !== id);
+    setLogs(newLogs);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newLogs));
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <div className="list-container">
+        <h2>睡眠ログ一覧</h2>
+        <ul>
+          {logs.map((log) => (
+            <li key={log.id} className="list-item">
+              <div>
+                {new Date(log.sleepTime).toLocaleString()} -{' '}
+                {new Date(log.wakeTime).toLocaleString()}
+              </div>
+              {log.memo && <div>メモ: {log.memo}</div>}
+              <button onClick={() => handleDelete(log.id)}>削除</button>
+            </li>
+          ))}
+        </ul>
+        <SleepChart logs={logs} />
+      </div>
+    </div>
+  );
+};
+
+export default SleepLogList;

--- a/app/src/pages/SleepLogsPage.tsx
+++ b/app/src/pages/SleepLogsPage.tsx
@@ -1,0 +1,9 @@
+import SleepLogList from '../components/SleepLogList';
+
+export default function SleepLogsPage() {
+  return (
+    <div>
+      <SleepLogList />
+    </div>
+  );
+}

--- a/app/src/types/SleepLog.ts
+++ b/app/src/types/SleepLog.ts
@@ -1,0 +1,6 @@
+export interface SleepLog {
+  id: number;
+  sleepTime: number;
+  wakeTime: number;
+  memo?: string;
+}


### PR DESCRIPTION
## Summary
- implement `SleepLogList` with delete and `SleepChart`
- create `SleepLogsPage` and add routing
- define `SleepLog` type
- test log list rendering and deletion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687de3e9f540832494ea07f25e596d51