### PR TITLE
Fix SleepLog type imports

### DIFF
--- a/app/__tests__/SleepLogList.test.tsx
+++ b/app/__tests__/SleepLogList.test.tsx
@@ -1,7 +1,7 @@
 /// <reference types="@testing-library/jest-dom" />
 import { render, screen, fireEvent } from '@testing-library/react';
 import SleepLogList from '../src/components/SleepLogList';
-import { SleepLog } from '../src/types/SleepLog';
+import type { SleepLog } from '../src/types/SleepLog';
 
 describe('SleepLogList', () => {
   const logs: SleepLog[] = [

--- a/app/src/components/SleepChart.tsx
+++ b/app/src/components/SleepChart.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SleepLog } from '../types/SleepLog';
+import type { SleepLog } from '../types/SleepLog';
 
 interface Props {
   logs: SleepLog[];

--- a/app/src/components/SleepLogList.tsx
+++ b/app/src/components/SleepLogList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { SleepLog } from '../types/SleepLog';
+import type { SleepLog } from '../types/SleepLog';
 import SleepChart from './SleepChart';
 
 const STORAGE_KEY = 'sleepLogs';


### PR DESCRIPTION
## Summary
- fix import statements to use type-only syntax for `SleepLog`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687de63c3d3083249a1299316c68874c