### PR TITLE
Add weekly sleep bar chart

### DIFF
--- a/app/__tests__/SleepLogList.test.tsx
+++ b/app/__tests__/SleepLogList.test.tsx
@@ -19,17 +19,20 @@ describe('SleepLogList', () => {
   ];
 
   beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-03'));
     localStorage.setItem('sleepLogs', JSON.stringify(logs));
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     localStorage.clear();
   });
 
   test('renders logs and bars', async () => {
     render(<SleepLogList />);
     expect(await screen.findAllByRole('listitem')).toHaveLength(2);
-    expect(screen.getAllByRole('progressbar')).toHaveLength(2);
+    expect(screen.getAllByRole('progressbar')).toHaveLength(7);
   });
 
   test('deletes a log', async () => {

--- a/app/src/components/SleepChart.tsx
+++ b/app/src/components/SleepChart.tsx
@@ -9,9 +9,22 @@ const BAR_WIDTH = 20;
 const SCALE = 20; // px per hour
 
 const SleepChart: React.FC<Props> = ({ logs }) => {
-  const durations = logs.map((l) =>
-    Math.max(0, (l.wakeTime - l.sleepTime) / 3600000)
-  );
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const days = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(today);
+    d.setDate(today.getDate() - 6 + i);
+    return d;
+  });
+
+  const durations = days.map((d) => {
+    const dateStr = d.toISOString().split('T')[0];
+    const log = logs.find(
+      (l) => new Date(l.sleepTime).toISOString().split('T')[0] === dateStr
+    );
+    return log ? Math.max(0, (log.wakeTime - log.sleepTime) / 3600000) : 0;
+  });
+
   const max = Math.max(...durations, 0);
   const height = max * SCALE;
 
@@ -19,19 +32,32 @@ const SleepChart: React.FC<Props> = ({ logs }) => {
     <div
       role="group"
       aria-label="睡眠時間グラフ"
-      style={{ display: 'flex', alignItems: 'flex-end', gap: '4px', height }}
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'flex-end',
+        gap: '8px',
+        background: '#eee',
+        padding: '1rem',
+        height
+      }}
     >
       {durations.map((d, i) => (
-        <div
-          key={logs[i].id}
-          role="progressbar"
-          aria-label={`${d.toFixed(1)}h`}
-          style={{
-            width: BAR_WIDTH,
-            height: d * SCALE,
-            background: 'skyblue'
-          }}
-        />
+        <div key={i} style={{ textAlign: 'center' }}>
+          <div
+            role="progressbar"
+            aria-label={`${d.toFixed(1)}h`}
+            style={{
+              width: BAR_WIDTH,
+              height: d * SCALE,
+              background: 'lightblue',
+              margin: '0 auto'
+            }}
+          />
+          <div style={{ fontSize: '0.75rem' }}>{
+            `${days[i].getMonth() + 1}/${days[i].getDate()}`
+          }</div>
+        </div>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- visualize last week's sleep duration as a vertical bar chart
- update tests to expect seven bars

## Testing
- `npm test` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687de7e56f74832496d8c1c3e1c11473