### PR TITLE
Display sleep duration in logs

### DIFF
--- a/app/__tests__/SleepLogList.test.tsx
+++ b/app/__tests__/SleepLogList.test.tsx
@@ -33,6 +33,7 @@ describe('SleepLogList', () => {
     render(<SleepLogList />);
     expect(await screen.findAllByRole('listitem')).toHaveLength(2);
     expect(screen.getAllByRole('progressbar')).toHaveLength(7);
+    expect(screen.getAllByText('睡眠時間: 8.0h')).toHaveLength(2);
   });
 
   test('deletes a log', async () => {

--- a/app/src/components/SleepLogList.tsx
+++ b/app/src/components/SleepLogList.tsx
@@ -24,16 +24,21 @@ const SleepLogList: React.FC = () => {
       <div className="list-container">
         <h2>睡眠ログ一覧</h2>
         <ul>
-          {logs.map((log) => (
-            <li key={log.id} className="list-item">
-              <div>
-                {new Date(log.sleepTime).toLocaleString()} -{' '}
-                {new Date(log.wakeTime).toLocaleString()}
-              </div>
-              {log.memo && <div>メモ: {log.memo}</div>}
-              <button onClick={() => handleDelete(log.id)}>削除</button>
-            </li>
-          ))}
+          {logs.map((log) => {
+            const duration =
+              Math.max(0, (log.wakeTime - log.sleepTime) / 3600000);
+            return (
+              <li key={log.id} className="list-item">
+                <div>
+                  {new Date(log.sleepTime).toLocaleString()} -{' '}
+                  {new Date(log.wakeTime).toLocaleString()}
+                </div>
+                <div>睡眠時間: {duration.toFixed(1)}h</div>
+                {log.memo && <div>メモ: {log.memo}</div>}
+                <button onClick={() => handleDelete(log.id)}>削除</button>
+              </li>
+            );
+          })}
         </ul>
         <SleepChart logs={logs} />
       </div>


### PR DESCRIPTION
## Summary
- show sleep duration for each log
- update tests for new log display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687decc818548324a64689f6d91ded37